### PR TITLE
WIP - Add versioning/snapshots to DocSet

### DIFF
--- a/src/doc_set.js
+++ b/src/doc_set.js
@@ -1,4 +1,4 @@
-const { Map, Set } = require('immutable')
+const { List, Map, Set } = require('immutable')
 const uuid = require('./uuid')
 const FreezeAPI = require('./freeze_api')
 
@@ -12,20 +12,86 @@ class DocSet {
     return this.docs.keys()
   }
 
-  getDoc (docId) {
+  getHistory (docId) {
     return this.docs.get(docId)
   }
 
-  setDoc (docId, doc) {
-    this.docs = this.docs.set(docId, doc)
+  getCurrentSnapshot (docId) {
+    const docs = this.getHistory(docId)
+    if (docs) {
+      return docs.last()
+    } else {
+      return Map()
+    }
+  }
+
+  getDoc (docId) {
+    const snapshot = this.getCurrentSnapshot(docId)
+    if (snapshot) {
+      return snapshot.get("doc")
+    } else {
+      return null
+    }
+  }
+
+  getCurrentVersion (docId) {
+    const snapshot = this.getCurrentSnapshot(docId)
+    return snapshot.get("version")
+  }
+
+  clockIsOnCurrentSnapshot (docId, version) {
+    const currentVersion = this.getCurrentVersion(docId)
+    return currentVersion === version
+  }
+
+  createNewSnapshot (docId, currentDoc, version) {
+    const oldDoc = this.getDoc(docId)
+    let docList = this.getHistory(docId)
+    let newSnapshot = Map({
+      "doc": currentDoc,
+      "version": version || this.getCurrentVersion(docId) + 1,
+      "startTimestamp": new Date(),
+    })
+    docList = docList.push(newSnapshot)
+    this.docs = this.docs.set(docId, docList)
+    this.handlers.forEach(handler => handler(docId, currentDoc))
+  }
+
+  setDoc (docId, doc, version) {
+    let docList = this.getHistory(docId);
+    if (docList) {
+      docList = docList.setIn([docList.size - 1, "doc"], doc)
+      this.docs = this.docs.set(docId, docList)
+    } else {
+      let snapshot = Map({
+        "doc": doc,
+        "version": version || 0,
+        "startTimestamp": new Date(),
+      })
+      this.docs = this.docs.set(docId, List([snapshot]))
+    }
     this.handlers.forEach(handler => handler(docId, doc))
   }
 
-  applyChanges (docId, changes) {
-    let doc = this.docs.get(docId) || FreezeAPI.init(uuid())
-    doc = FreezeAPI.applyChanges(doc, changes, true)
-    this.setDoc(docId, doc)
-    return doc
+  applyChanges (docId, changes, version) {
+    let doc;
+    if (this.clockIsOnCurrentSnapshot(docId, version) || this.getCurrentVersion(docId) === undefined || this.getCurrentVersion(docId) === null) {
+      doc = this.getDoc(docId) || FreezeAPI.init(uuid(), version)
+      doc = FreezeAPI.applyChanges(doc, changes, true)
+      this.setDoc(docId, doc, version)
+      return doc
+    } else {
+      if (version > this.getCurrentVersion(docId)) {
+        // If changes refer to a newer version, add the latest version to the
+        // DocSet.
+        doc = this.getDoc(docId)
+        doc = FreezeAPI.init(doc._actorId, version)
+        doc = FreezeAPI.applyChanges(doc, changes, true)
+        this.createNewSnapshot(docId, doc, version)
+        return doc
+      }
+      return null
+    }
   }
 
   registerHandler (handler) {

--- a/src/freeze_api.js
+++ b/src/freeze_api.js
@@ -236,8 +236,8 @@ function rootObject(state, rootObj) {
   return rootObj
 }
 
-function init(actorId) {
-  const [opSet, rootObj] = materialize(OpSet.init())
+function init(actorId, version) {
+  const [opSet, rootObj] = materialize(OpSet.init(version || 0))
   const state = Map({actorId, opSet})
   return rootObject(state, rootObj)
 }

--- a/src/op_set.js
+++ b/src/op_set.js
@@ -269,12 +269,12 @@ function applyQueuedOps(opSet) {
   }
 }
 
-function init() {
+function init(version) {
   return Map()
     .set('states',   Map())
     .set('history',  List())
     .set('byObject', Map().set(ROOT_ID, Map()))
-    .set('clock',    Map())
+    .set('clock',    Map({"version": version || 0}))
     .set('deps',     Map())
     .set('local',    List())
     .set('queue',    List())


### PR DESCRIPTION
Known Limitations / Issues: Right now this will have a problem if two different users create a new version from a base version, essentially forking the document. This also may have problems with p2p distributed connections where there is no "central" server. Imagine if client A creates a new version but client B & C work together on an older version... then what happens?

Possible limited solution: Only allow the creator of the document to create a new version. This solution will only work for the case where there is a centralized "owner" for a document which is pretty limiting. Unfortunately, to do versioning and allowing multiple users to create a versions, we'll have to be able to handle forks (i.e. branching in git) which is discussed in https://github.com/automerge/automerge/issues/54